### PR TITLE
Remove un-secure content warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="style/style.css" />
   <link rel="stylesheet" type="text/css" href="style/tabzilla.css" media="screen" />
-  <script src="http://code.jquery.com/jquery-1.11.3.min.js"></script>
+  <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
 
 
   </script>


### PR DESCRIPTION
Just removed the leading `http:` from the jquey cdn url, which will load the url based on current page protocol whether it's **http** or **https**.
